### PR TITLE
Switch to ^-mode dependency for "hamming"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/hannesmcman/keyword-search#readme",
   "dependencies": {
-    "hamming": "0.0.2"
+    "hamming": "^0.0.2"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Allows the package to pick up bug fixes and enhancements – it'll accept 0.0.2 and 0.0.3, or 1.0.1 and 1.1.1, but not 0.1.0, because semver is essentially moved over one slot for v0 versions.